### PR TITLE
Fix events CSV parsing

### DIFF
--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -49,6 +49,7 @@ export async function getEvents(locale: Language): Promise<Event[]> {
     columns: ['EventID', 'Title', 'Description', 'ImagePath', 'City', 'Latitude', 'Longitude', 'Date', 'Hour', 'Type'],
     skip_empty_lines: true,
     relax_column_count: true,
+    from_line: 2,
   });
 
   const allEvents: Event[] = records.map((record: any) => ({
@@ -97,7 +98,6 @@ export async function getEventBySlug(slug: string, locale: Language): Promise<Ev
   return events.find((event) => event.slug === slug);
 }
 
-import { Language } from '@/lib/translations';
 
 export async function getBranches(locale: Language): Promise<Branch[]> {
   const csvFileName = locale === 'en' ? 'branches.en.csv' : 'branches.csv';


### PR DESCRIPTION
## Summary
- skip CSV header row when loading events
- remove duplicate import

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: cannot find module 'next')*

------
https://chatgpt.com/codex/tasks/task_b_686bd46154b08328aebdab52bd13f3b9