### PR TITLE
Add badges for events

### DIFF
--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -7,11 +7,38 @@ interface EventCardProps {
   event: Event;
 }
 
+const typeBadges: Record<string, { label: string; className: string }> = {
+  country_wide: {
+    label: 'Държавно честване',
+    className: 'bg-[var(--primary-accent-green)] text-white',
+  },
+  local_event: {
+    label: 'Възстановка',
+    className: 'bg-[var(--secondary-accent-ochre)] text-white',
+  },
+  national_event: {
+    label: 'Национална Възстановка',
+    className: 'bg-yellow-600 text-white',
+  },
+};
+
 const EventCard: React.FC<EventCardProps> = ({ event }) => {
+  const badge = typeBadges[event.Type];
+
   return (
-    <Link href={`/events/${event.slug}`} className="p-4 rounded-xl shadow hover:shadow-lg transition flex flex-col">
+    <Link
+      href={`/events/${event.slug}`}
+      className="p-4 rounded-xl shadow hover:shadow-lg transition flex flex-col"
+    >
       {event.ImagePath && (
-        <div className="w-full h-48 overflow-hidden rounded-md mb-4">
+        <div className="relative w-full h-48 overflow-hidden rounded-md mb-4">
+          {badge && (
+            <span
+              className={`${badge.className} absolute top-2 left-2 z-10 px-2 py-1 text-xs font-semibold rounded`}
+            >
+              {badge.label}
+            </span>
+          )}
           <Image
             src={event.ImagePath || '/images/events/placeholder.jpg'}
             alt={event.Title}


### PR DESCRIPTION
## Summary
- show an event type badge on each event card

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run type-check` *(fails: cannot find module 'next' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_b_686bd6ca3c24832884a020a71eba906b