### PR TITLE
Add badge for past events

### DIFF
--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -5,24 +5,25 @@ import { Event } from '@/lib/content';
 
 interface EventCardProps {
   event: Event;
+  isPast?: boolean;
 }
 
 const typeBadges: Record<string, { label: string; className: string }> = {
   country_wide: {
     label: 'Държавно честване',
-    className: 'bg-[var(--primary-accent-green)] text-white',
+    className: 'bg-[var(--primary-accent-green)] text-white border-2 border-black',
   },
   local_event: {
     label: 'Възстановка',
-    className: 'bg-[var(--secondary-accent-ochre)] text-white',
+    className: 'bg-[var(--secondary-accent-ochre)] text-white border-2 border-black',
   },
   national_event: {
     label: 'Национална Възстановка',
-    className: 'bg-yellow-600 text-white',
+    className: 'bg-yellow-600 text-white border-2 border-black',
   },
 };
 
-const EventCard: React.FC<EventCardProps> = ({ event }) => {
+const EventCard: React.FC<EventCardProps> = ({ event, isPast }) => {
   const badge = typeBadges[event.Type];
 
   return (
@@ -37,6 +38,13 @@ const EventCard: React.FC<EventCardProps> = ({ event }) => {
               className={`${badge.className} absolute top-2 left-2 z-10 px-2 py-1 text-xs font-semibold rounded`}
             >
               {badge.label}
+            </span>
+          )}
+          {isPast && (
+            <span
+              className="bg-gray-600 text-white border-2 border-black absolute top-2 right-2 z-10 px-2 py-1 text-xs font-semibold rounded"
+            >
+              Минало Събитие
             </span>
           )}
           <Image

--- a/src/components/EventsPageClient.tsx
+++ b/src/components/EventsPageClient.tsx
@@ -98,7 +98,7 @@ export default function EventsPageClient({ initialEvents }: EventsPageClientProp
               transition={{ duration: 0.5, delay: index * 0.1 }}
               className={isPast ? "opacity-30 grayscale pointer-events-none" : ""}
             >
-              <EventCard event={event} />
+              <EventCard event={event} isPast={isPast} />
             </motion.div>
           );
         })}


### PR DESCRIPTION
## Summary
- show borders on all badges with thicker stroke
- display a "Минало Събитие" badge when an event is in the past

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: Cannot find module 'next')*


------
https://chatgpt.com/codex/tasks/task_b_686bd83123108328ba1127acb1ff72cf