### PR TITLE
Adjust event badge colors

### DIFF
--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -11,11 +11,11 @@ interface EventCardProps {
 const typeBadges: Record<string, { label: string; className: string }> = {
   country_wide: {
     label: 'Държавно честване',
-    className: 'bg-[var(--primary-accent-green)] text-white border-2 border-black',
+    className: 'bg-blue-600 text-white border-2 border-black',
   },
   local_event: {
     label: 'Възстановка',
-    className: 'bg-[var(--secondary-accent-ochre)] text-white border-2 border-black',
+    className: 'bg-green-600 text-white border-2 border-black',
   },
   national_event: {
     label: 'Национална Възстановка',


### PR DESCRIPTION
## Summary
- change the `Възстановка` badge to green
- switch `Държавно честване` badge to blue

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_b_686bdc73c4e08328862ec3df1671ab3b