### PR TITLE
Handle undated events as active

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,12 @@ export default async function HomePage({ params: { lang } }: { params: { lang: L
   const now = new Date();
   now.setHours(0, 0, 0, 0);
 
-  const filteredUpcomingEvents = upcomingEvents.filter(event => new Date(event.Date) >= now);
+  const filteredUpcomingEvents = upcomingEvents.filter(event => {
+    if (!event.Date) return true;
+    const eventDate = new Date(event.Date);
+    if (isNaN(eventDate.getTime())) return true;
+    return eventDate >= now;
+  });
 
   // Take the first 3 upcoming events
   const recentEvents = filteredUpcomingEvents.slice(0, 3);

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -65,20 +65,29 @@ export async function getEvents(locale: Language): Promise<Event[]> {
   const now = new Date();
   now.setHours(0, 0, 0, 0);
 
-  const upcomingEvents: Event[] = [];
+  const upcomingWithDate: Event[] = [];
+  const upcomingWithoutDate: Event[] = [];
   const pastEvents: Event[] = [];
 
   allEvents.forEach(event => {
+    if (!event.Date) {
+      upcomingWithoutDate.push(event);
+      return;
+    }
+
     const eventDate = new Date(event.Date);
     eventDate.setHours(0, 0, 0, 0);
-    if (eventDate >= now) {
-      upcomingEvents.push(event);
+
+    if (isNaN(eventDate.getTime())) {
+      upcomingWithoutDate.push(event);
+    } else if (eventDate >= now) {
+      upcomingWithDate.push(event);
     } else {
       pastEvents.push(event);
     }
   });
 
-  upcomingEvents.sort((a, b) => {
+  upcomingWithDate.sort((a, b) => {
     const dateA = new Date(a.Date);
     const dateB = new Date(b.Date);
     return dateA.getTime() - dateB.getTime();
@@ -90,7 +99,7 @@ export async function getEvents(locale: Language): Promise<Event[]> {
     return dateB.getTime() - dateA.getTime(); // Sort past events by most recent first
   });
 
-  return [...upcomingEvents, ...pastEvents];
+  return [...upcomingWithDate, ...upcomingWithoutDate, ...pastEvents];
 }
 
 export async function getEventBySlug(slug: string, locale: Language): Promise<Event | undefined> {


### PR DESCRIPTION
## Summary
- classify events missing dates as active events
- keep undated events at the end of active events
- include undated events when selecting upcoming events for the homepage

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: cannot find module `next`)*

------
https://chatgpt.com/codex/tasks/task_b_686be2bf4cd08328b940811da2394304