### PR TITLE
Fix quote handling in CSV parser

### DIFF
--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -49,6 +49,9 @@ export async function getEvents(locale: Language): Promise<Event[]> {
     columns: ['EventID', 'Title', 'Description', 'ImagePath', 'City', 'Latitude', 'Longitude', 'Date', 'Hour', 'Type'],
     skip_empty_lines: true,
     relax_column_count: true,
+    // Some titles contain double quotes for emphasis. Allow such quotes
+    // without requiring them to be escaped.
+    relax_quotes: true,
     from_line: 2,
   });
 


### PR DESCRIPTION
## Summary
- relax csv parsing to allow double quotes inside fields

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_b_686be510a524832895fbe4f7f8b699f6