### PR TITLE
Add bilingual About page content

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,8 +1,24 @@
 'use client';
 
 import { motion } from "framer-motion";
+import { useLanguage } from '@/contexts/LanguageContext';
 
 export default function About() {
+  const { t } = useLanguage();
+
+  const bullets = [
+    'aboutBullet1',
+    'aboutBullet2',
+    'aboutBullet3',
+    'aboutBullet4',
+    'aboutBullet5',
+    'aboutBullet6',
+    'aboutBullet7',
+    'aboutBullet8',
+    'aboutBullet9',
+    'aboutBullet10',
+  ] as const;
+
   return (
     <motion.div
       initial={{ opacity: 0, y: 50 }}
@@ -11,17 +27,13 @@ export default function About() {
       transition={{ duration: 0.6 }}
       className="max-w-6xl mx-auto p-8 text-foreground"
     >
-      <h1 className="text-3xl font-bold mb-6">About Us</h1>
-      <p className="text-lg mb-4">
-        Our organization was founded with the mission to serve our community.
-      </p>
-      <p className="mb-4">
-        We believe in making a difference through dedicated service and community engagement.
-      </p>
-      <h2 className="text-2xl font-semibold mb-3">Our Mission</h2>
-      <p>
-        To create positive change and support those in need in our local community.
-      </p>
+      <h1 className="text-3xl font-bold mb-6">{t('about')}</h1>
+      <h2 className="text-2xl font-semibold mb-4">{t('aboutMissionTitle')}</h2>
+      <ul className="list-disc pl-5 space-y-2">
+        {bullets.map(key => (
+          <li key={key}>{t(key)}</li>
+        ))}
+      </ul>
     </motion.div>
   )
 }

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -59,6 +59,19 @@ export const translations = {
     
     // Organization name
     organizationName: "NATIONAL SOCIETY \"TRADITION\""
+    ,
+    // About page
+    aboutMissionTitle: "Our Mission",
+    aboutBullet1: "The overall mission of the society is patriotic-educational influence on the population, especially on youth, by instilling love and respect for national ideals and their defenders.",
+    aboutBullet2: "We have branches in over 40 cities and over 950 members.",
+    aboutBullet3: "We organize and participate in military-historical reenactments, exhibitions, and commemorations of episodes from historical events.",
+    aboutBullet4: "We cooperate with and assist state and public bodies, organizations, and individuals in the country and abroad.",
+    aboutBullet5: "We maintain a specialized fund of literature and artifacts and publish our own editions, auxiliary and promotional materials.",
+    aboutBullet6: "We arrange the exchange of specialized literature, uniform elements, badges, military symbols, and other collectibles.",
+    aboutBullet7: "We make proposals and participate in working groups to improve legislation related to our activities.",
+    aboutBullet8: "We provide expert opinions and assessments to state and judicial authorities, individuals and legal entities regarding the origin, authenticity, and condition of weapons and collectible items.",
+    aboutBullet9: "We conduct over 50 different events each year and provide practical and legal assistance to society members.",
+    aboutBullet10: "We support museum exhibitions to enhance their authenticity and preserve, maintain, and restore soldiers' monuments."
   },
   bg: {
     // Navigation
@@ -114,6 +127,18 @@ export const translations = {
     
     // Organization name
     organizationName: "НАЦИОНАЛНО ДРУЖЕСТВО \"ТРАДИЦИЯ\"",
+    // About page
+    aboutMissionTitle: "Нашата мисия",
+    aboutBullet1: "Общата мисия на дружеството е патриотично-възпитателно въздействие върху населението, особено върху младежта, чрез формиране на любов и уважение към националните идеали и техните защитници.",
+    aboutBullet2: "Имаме клонове в над 40 града и в дружеството членуват над 950 човека.",
+    aboutBullet3: "Организираме и участваме във военно–исторически възстановки, изложби и чествания на епизоди от исторически събития.",
+    aboutBullet4: "Сътрудничим и оказваме съдействие на държавни и обществени органи, организации и физически лица в страната и чужбина.",
+    aboutBullet5: "Поддържаме специализиран фонд от литература и предмети и отпечатваме собствени издания, помощни и рекламни материали.",
+    aboutBullet6: "Организираме обмен на специализирана литература, униформени елементи, нагръдни знаци, военни символи и други колекционерски предмети.",
+    aboutBullet7: "Даваме предложения и участваме в работни групи за усъвършенстване на законодателството, свързано с дейността ни.",
+    aboutBullet8: "Даваме експертни мнения и оценки на държавни и съдебни органи, физически и юридически лица относно произхода, автентичността и състоянието на оръжия и колекционерски предмети.",
+    aboutBullet9: "Провеждаме над 50 различни мероприятия всяка година и осигуряваме практическа и правна помощ на членовете на дружеството.",
+    aboutBullet10: "Подпомагаме музейни експозиции за повишаване на автентичността им и опазваме, поддържаме и възстановяваме войнишки паметници."
   }
 } as const;
 


### PR DESCRIPTION
## Summary
- translate About page content and render bullet list
- add new translation keys for About page

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_b_686be8062a848328a844a3c809e76d56