### PR TITLE
Add GitHub Pages deployment steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,22 @@ To run this project locally:
     npm run dev
     ```
     Open [http://localhost:3000](http://localhost:3000) (or the port indicated in your terminal) in your browser.
+
+## Deploying to GitHub Pages
+
+1. **Set the base path**
+   Add your repository name to `.env.local` using `NEXT_PUBLIC_BASE_PATH`.
+   For a repository called `my-site`:
+   ```bash
+   echo "NEXT_PUBLIC_BASE_PATH=my-site" >> .env.local
+   ```
+2. **Export the static site**
+   ```bash
+   npm run export
+   ```
+3. **Publish to GitHub Pages**
+   ```bash
+   git subtree push --prefix out origin gh-pages
+   ```
+   Then enable GitHub Pages from the repository settings, selecting the `gh-pages` branch.
+   Your site will be available at `https://<your-user>.github.io/<repository>/`.

--- a/env.example
+++ b/env.example
@@ -5,4 +5,8 @@ NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=your_google_maps_api_key_here
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
 
 # Contact form email (optional)
-CONTACT_EMAIL=contact@yourorganization.org 
+CONTACT_EMAIL=contact@yourorganization.org
+
+# Base path for GitHub Pages
+# Example: my-project
+NEXT_PUBLIC_BASE_PATH=

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,17 +1,24 @@
 import type { NextConfig } from 'next'
 
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH
+  ? `/${process.env.NEXT_PUBLIC_BASE_PATH.replace(/^\//, '')}`
+  : ''
+
 const nextConfig: NextConfig = {
-  /* config options here */
-  webpack: (config, { isServer }) => {
+  output: 'export',
+  basePath,
+  assetPrefix: basePath ? `${basePath}/` : undefined,
+  images: { unoptimized: true },
+  webpack: (config) => {
     config.plugins.push(
       new (require('webpack').DefinePlugin)({
-        'process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY': JSON.stringify(process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY),
+        'process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY': JSON.stringify(
+          process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY
+        ),
       })
-    );
-    return config;
+    )
+    return config
   },
 }
 
-console.log("NEXT_PUBLIC_GOOGLE_MAPS_API_KEY in next.config.ts:", process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY);
-
-export default nextConfig 
+export default nextConfig

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "export": "next build && next export",
     "start": "next start",
     "lint": "next lint",
     "type-check": "tsc --noEmit"


### PR DESCRIPTION
## Summary
- add GitHub Pages base path variable example
- support static export in `next.config.ts`
- add `npm run export` script
- document how to deploy to GitHub Pages

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_b_686beaeb6090832896a19267f9316bda