### PR TITLE
Reorder nav menu

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -18,7 +18,7 @@ export default function Navigation() {
           </span>
         </div>
         <nav className="space-x-6">
-          {['Home', 'Gallery', 'Events', 'About', 'Contact'].map((item) => (
+          {['Home', 'Gallery', 'Events', 'Contact', 'About'].map((item) => (
             <Link
               key={item}
               href={`/${item.toLowerCase() === 'home' ? '' : item.toLowerCase()}`}

--- a/src/components/TranslatableNavigation.tsx
+++ b/src/components/TranslatableNavigation.tsx
@@ -13,9 +13,9 @@ export default function TranslatableNavigation() {
     { key: 'home', href: '' },
     { key: 'gallery', href: 'gallery' },
     { key: 'events', href: 'events' },
-    { key: 'about', href: 'about' },
+    { key: 'branches', href: 'branches' },
     { key: 'contact', href: 'contact' },
-    { key: 'branches', href: 'branches' }
+    { key: 'about', href: 'about' }
   ];
 
   return (


### PR DESCRIPTION
## Summary
- update menu ordering in Navigation components so Contact and About are last

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: cannot find module 'next' or corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_b_686bedb534b88328b2b621ed6625745a