### PR TITLE
Translate contact page

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,16 +1,22 @@
+"use client";
+
+import { useLanguage } from '@/contexts/LanguageContext';
+
 export default function Contact() {
+  const { t } = useLanguage();
+
   return (
     <div className="max-w-6xl mx-auto p-8 text-[var(--text-charcoal)]">
-      <h1 className="text-3xl font-bold mb-6">Contact Us</h1>
+      <h1 className="text-3xl font-bold mb-6">{t('contact')}</h1>
       <p className="text-lg mb-6">
-        Get in touch with us to learn more about our work or to get involved.
+        {t('contactSubtitle')}
       </p>
       
       <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
         <div>
-          <h2 className="text-2xl font-semibold mb-4">Contact Information</h2>
-          <p className="mb-2"><strong>Email:</strong> nationaltradition@abv.bg</p>
-          <p className="mb-2"><strong>Address:</strong> 
+          <h2 className="text-2xl font-semibold mb-4">{t('contactInformation')}</h2>
+          <p className="mb-2"><strong>{t('email')}:</strong> nationaltradition@abv.bg</p>
+          <p className="mb-2"><strong>{t('address')}:</strong>
             Държава: БЪЛГАРИЯ, Област: София (столица), Община: Столична,
             гр. София, п.к. 1407, р-н Лозенец,
             ж.к. Лозенец, бул./ул. Любата, бл. 14, вх. Г, ет. 6, ап. 66
@@ -18,28 +24,28 @@ export default function Contact() {
         </div>
         
         <div>
-          <h2 className="text-2xl font-semibold mb-4">Send us a Message</h2>
+          <h2 className="text-2xl font-semibold mb-4">{t('sendUsMessage')}</h2>
           <form className="space-y-4">
-            <input 
-              type="text" 
-              placeholder="Your Name" 
+            <input
+              type="text"
+              placeholder={t('yourName')}
               className="w-full p-2 border border-gray-300 rounded"
             />
-            <input 
-              type="email" 
-              placeholder="Your Email" 
+            <input
+              type="email"
+              placeholder={t('yourEmail')}
               className="w-full p-2 border border-gray-300 rounded"
             />
-            <textarea 
-              placeholder="Your Message" 
+            <textarea
+              placeholder={t('yourMessage')}
               rows={4}
               className="w-full p-2 border border-gray-300 rounded"
             ></textarea>
-            <button 
-              type="submit" 
+            <button
+              type="submit"
               className="bg-[var(--primary-accent-green)] text-white px-6 py-2 rounded hover:bg-[var(--secondary-accent-ochre)]"
             >
-              Send Message
+              {t('sendMessage')}
             </button>
           </form>
         </div>

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -45,6 +45,16 @@ export const translations = {
     location: "Location",
     description: "Description",
 
+    // Contact page
+    contactSubtitle: "Get in touch with us to learn more about our work or to get involved.",
+    contactInformation: "Contact Information",
+    address: "Address",
+    sendUsMessage: "Send us a Message",
+    yourName: "Your Name",
+    yourEmail: "Your Email",
+    yourMessage: "Your Message",
+    sendMessage: "Send Message",
+
     // Announcements section
     newAnnouncement: "A nation that does not remember its past has no present and no future.",
     
@@ -112,6 +122,16 @@ export const translations = {
     date: "Дата",
     location: "Място",
     description: "Описание",
+
+    // Contact page
+    contactSubtitle: "Свържете се с нас, за да научите повече за нашата работа или да се включите.",
+    contactInformation: "Информация за контакт",
+    address: "Адрес",
+    sendUsMessage: "Изпратете ни съобщение",
+    yourName: "Вашето име",
+    yourEmail: "Вашият имейл",
+    yourMessage: "Вашето съобщение",
+    sendMessage: "Изпрати",
 
     // Announcements section
     newAnnouncement: "Народ, който не помни миналото си, няма настояще и бъдеще.",


### PR DESCRIPTION
## Summary
- localize contact page text
- add translations for contact page labels

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: cannot find module 'next')*

------
https://chatgpt.com/codex/tasks/task_b_686beeb5bea8832898cf67838ff2e44a