### PR TITLE
Fix missing Bulgarian email translation

### DIFF
--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -121,6 +121,7 @@ export const translations = {
     title: "Име",
     date: "Дата",
     location: "Място",
+    email: "Имейл",
     description: "Описание",
 
     // Contact page


### PR DESCRIPTION
## Summary
- add Bulgarian translation for `email`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_b_686bf042578083288d085282876ad961