### PR TITLE
Fix gallery API export mode

### DIFF
--- a/src/app/api/gallery/[album]/route.ts
+++ b/src/app/api/gallery/[album]/route.ts
@@ -2,6 +2,9 @@ import { NextResponse } from 'next/server';
 import fs from 'fs/promises';
 import path from 'path';
 
+// Ensure this route can be statically exported
+export const dynamic = 'force-static'
+
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ album: string }> }

--- a/src/app/api/gallery/route.ts
+++ b/src/app/api/gallery/route.ts
@@ -2,6 +2,9 @@ import { NextResponse } from 'next/server';
 import fs from 'fs/promises';
 import path from 'path';
 
+// Ensure this route can be statically exported
+export const dynamic = 'force-static'
+
 export async function GET() {
   try {
     const galleryPath = path.join(process.cwd(), 'public', 'gallery');


### PR DESCRIPTION
## Summary
- declare gallery API routes as force-static to work with static export

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_b_686bf6e8038083289a342aabb8f2889f