### PR TITLE
Fix mobile banner cropping

### DIFF
--- a/src/components/HomePageClient.tsx
+++ b/src/components/HomePageClient.tsx
@@ -18,7 +18,7 @@ export default function HomePageClient({ recentEvents }: HomePageClientProps) {
   return (
     <div className="flex flex-col min-h-screen text-[var(--text-charcoal)]">
       {/* Hero */}
-      <section className="relative w-full h-[25vw] min-h-[150px] max-h-[300px]">
+      <section className="relative w-full h-[28vw] min-h-[100px] sm:h-[25vw] sm:min-h-[150px] max-h-[300px]">
         <Image
           src="/images/site-banner.webp"
           alt="Traditsia Banner"


### PR DESCRIPTION
## Summary
- enlarge the hero section height on small screens so the banner crops less severely

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: cannot find module 'next' etc.)*

------
https://chatgpt.com/codex/tasks/task_b_686bf894911c832893ca6f3fa5712ee2