### PR TITLE
Fix missing coordinates default

### DIFF
--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -58,8 +58,8 @@ export async function getEvents(locale: Language): Promise<Event[]> {
   const allEvents: Event[] = records.map((record: any) => ({
     ...record,
     EventID: (record.EventID || '').padStart(5, '0'),
-    Latitude: parseFloat(record.Latitude) || 0,
-    Longitude: parseFloat(record.Longitude) || 0,
+    Latitude: parseFloat(record.Latitude),
+    Longitude: parseFloat(record.Longitude),
     slug: generateSlug(record.Title || ''),
     Type: record.Type || '',
     ImagePath: String(record.ImagePath || '').trim() || '/images/events/placeholder.jpg',


### PR DESCRIPTION
## Summary
- do not default event coordinates to (0, 0)

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_b_686bfa3da3a8832880b78ffbc74de49d