### PR TITLE
Align page spacing and container widths

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -25,7 +25,7 @@ export default function About() {
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true, amount: 0.3 }}
       transition={{ duration: 0.6 }}
-      className="max-w-6xl mx-auto p-8 text-foreground"
+      className="max-w-6xl mx-auto px-8 py-12 text-foreground"
     >
       <h1 className="text-3xl font-bold mb-6">{t('about')}</h1>
       <h2 className="text-2xl font-semibold mb-4">{t('aboutMissionTitle')}</h2>

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -6,7 +6,7 @@ export default function Contact() {
   const { t } = useLanguage();
 
   return (
-    <div className="max-w-6xl mx-auto p-8 text-[var(--text-charcoal)]">
+    <div className="max-w-6xl mx-auto px-8 py-12 text-[var(--text-charcoal)]">
       <h1 className="text-3xl font-bold mb-6">{t('contact')}</h1>
       <p className="text-lg mb-6">
         {t('contactSubtitle')}

--- a/src/app/gallery/[album]/page.tsx
+++ b/src/app/gallery/[album]/page.tsx
@@ -76,7 +76,7 @@ export default function AlbumPage() {
   if (error) {
     return (
       <div className="flex flex-col min-h-screen bg-background text-foreground">
-        <div className="container mx-auto py-12 px-6">
+        <div className="max-w-6xl mx-auto py-12 px-6">
           <Link href="/gallery" className="text-blue-600 hover:underline mb-6 inline-block">
             &larr; Back to {t('gallery')}
           </Link>
@@ -92,7 +92,7 @@ export default function AlbumPage() {
   if (loading) {
     return (
       <div className="flex flex-col min-h-screen bg-background text-foreground">
-        <div className="container mx-auto py-12 px-6">
+        <div className="max-w-6xl mx-auto py-12 px-6">
           <Link href="/gallery" className="text-blue-600 hover:underline mb-6 inline-block">
             &larr; Back to {t('gallery')}
           </Link>
@@ -105,7 +105,7 @@ export default function AlbumPage() {
 
   return (
     <div className="flex flex-col min-h-screen bg-background text-foreground">
-      <div className="container mx-auto py-12 px-6">
+      <div className="max-w-6xl mx-auto py-12 px-6">
         <Link href="/gallery" className="text-blue-600 hover:underline mb-6 inline-block">
           &larr; Back to {t('gallery')}
         </Link>

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -43,7 +43,7 @@ export default function GalleryPage() {
   if (loading) {
     return (
       <div className="flex flex-col min-h-screen text-[var(--text-charcoal)]">
-        <div className="container mx-auto py-12">
+        <div className="max-w-6xl mx-auto py-12">
           <h1 className="text-3xl font-bold mb-8">{t('gallery')}</h1>
           <div className="text-center">Loading albums...</div>
         </div>
@@ -54,7 +54,7 @@ export default function GalleryPage() {
   if (error) {
     return (
       <div className="flex flex-col min-h-screen text-[var(--text-charcoal)]">
-        <div className="container mx-auto py-12">
+        <div className="max-w-6xl mx-auto py-12">
           <h1 className="text-3xl font-bold mb-8">{t('gallery')}</h1>
           <div className="text-center text-red-600">
             <p>Error loading gallery: {error}</p>
@@ -66,7 +66,7 @@ export default function GalleryPage() {
 
   return (
     <div className="flex flex-col min-h-screen text-[var(--text-charcoal)]">
-      <div className="container mx-auto py-12 px-6">
+      <div className="max-w-6xl mx-auto py-12 px-6">
         <h1 className="text-3xl font-bold mb-8">{t('gallery')}</h1>
         
         {albums.length === 0 ? (

--- a/src/components/BranchesClient.tsx
+++ b/src/components/BranchesClient.tsx
@@ -28,7 +28,7 @@ export default function BranchesClient({ branches }: BranchesClientProps) {
   }));
 
   return (
-    <div className="container mx-auto py-8 px-6">
+    <div className="max-w-6xl mx-auto py-12 px-6">
       <h1 className="text-3xl font-bold mb-8">{t('branches')}</h1>
       
       <div className="mb-8">

--- a/src/components/EventDetailsClient.tsx
+++ b/src/components/EventDetailsClient.tsx
@@ -39,7 +39,7 @@ export default function EventDetailsClient({ event }: EventDetailsClientProps) {
   );
 
   return (
-    <div className="container mx-auto px-4 py-8">
+    <div className="max-w-6xl mx-auto px-4 py-12">
       <div className="max-w-6xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-8">
         {/* Left Column: Image and Map */}
         <div className="space-y-8">

--- a/src/components/EventsPageClient.tsx
+++ b/src/components/EventsPageClient.tsx
@@ -66,7 +66,7 @@ export default function EventsPageClient({ initialEvents }: EventsPageClientProp
   ];
 
   return (
-    <div className="container mx-auto py-8 px-6">
+    <div className="max-w-6xl mx-auto py-12 px-6">
       <h1 className="text-3xl font-bold mb-8">{t('events')}</h1>
       <div className="mb-4">
         <label htmlFor="month-select" className="mr-2">{t('filterByMonth')}</label>

--- a/src/components/HomePageClient.tsx
+++ b/src/components/HomePageClient.tsx
@@ -18,7 +18,7 @@ export default function HomePageClient({ recentEvents }: HomePageClientProps) {
   return (
     <div className="flex flex-col min-h-screen text-[var(--text-charcoal)]">
       {/* Hero */}
-      <section className="relative w-full h-[28vw] min-h-[100px] sm:h-[25vw] sm:min-h-[150px] max-h-[300px]">
+      <section className="relative w-full h-[28vw] min-h-[100px] sm:h-[25vw] sm:min-h-[150px] max-h-[300px] mb-8">
         <Image
           src="/images/site-banner.webp"
           alt="Traditsia Banner"
@@ -30,7 +30,7 @@ export default function HomePageClient({ recentEvents }: HomePageClientProps) {
       </section>
 
       {/* Upcoming Events */}
-      <main className="flex-grow container mx-auto px-6 py-12">
+      <main className="flex-grow max-w-6xl mx-auto px-6 py-12">
         <h2 className="text-2xl font-bold mb-6">{t('upcomingEvents')}</h2>
         <div className="grid gap-6 md:grid-cols-3">
           {recentEvents.map((event) => (
@@ -39,7 +39,7 @@ export default function HomePageClient({ recentEvents }: HomePageClientProps) {
         </div>
 
         {/* Announcements & News */}
-        <section className="mt-12 bg-[var(--secondary-accent-ochre)] p-6 rounded-lg">
+        <section className="my-8 bg-[var(--secondary-accent-ochre)] p-6 rounded-lg">
           <p className="font-caveat text-4xl font-bold text-[var(--text-charcoal)]">
             {t('newAnnouncement')}
           </p>
@@ -47,8 +47,8 @@ export default function HomePageClient({ recentEvents }: HomePageClientProps) {
       </main>
 
       {/* Footer */}
-      <footer className="bg-[var(--primary-accent-green)] text-white py-8">
-        <div className="container mx-auto px-6 flex flex-col md:flex-row justify-between">
+      <footer className="bg-[var(--primary-accent-green)] text-white py-12">
+        <div className="max-w-6xl mx-auto px-6 flex flex-col md:flex-row justify-between">
           <div>
             <p>{t('contactEmail')}</p>
             <p>{t('contactPhone')}</p>

--- a/src/components/TranslatableNavigation.tsx
+++ b/src/components/TranslatableNavigation.tsx
@@ -20,7 +20,7 @@ export default function TranslatableNavigation() {
 
   return (
     <header className="bg-[var(--background-soft-cream)] shadow-md">
-      <div className="container mx-auto flex items-center justify-between py-4 px-6">
+      <div className="max-w-6xl mx-auto flex items-center justify-between py-4 px-6">
         <Link href="/" className="flex items-center space-x-4 cursor-pointer">
           <Image
             src="/images/gerb.jpg"


### PR DESCRIPTION
## Summary
- make containers `max-w-6xl mx-auto`
- use `py-12` and `my-8` for consistent section spacing

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_686bf9a052908328a78345b7dbaf0eea