### PR TITLE
Fix slug generation for events

### DIFF
--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -30,9 +30,19 @@ export interface Branch {
   Longitude: number;
 }
 
+const transliterate = (text: string) => {
+  const map: Record<string, string> = {
+    'а': 'a', 'б': 'b', 'в': 'v', 'г': 'g', 'д': 'd', 'е': 'e', 'ж': 'zh',
+    'з': 'z', 'и': 'i', 'й': 'y', 'к': 'k', 'л': 'l', 'м': 'm', 'н': 'n',
+    'о': 'o', 'п': 'p', 'р': 'r', 'с': 's', 'т': 't', 'у': 'u', 'ф': 'f',
+    'х': 'h', 'ц': 'ts', 'ч': 'ch', 'ш': 'sh', 'щ': 'sht', 'ъ': 'a',
+    'ь': 'y', 'ю': 'yu', 'я': 'ya'
+  };
+  return text.split('').map(ch => map[ch] ?? ch).join('');
+};
+
 const generateSlug = (title: string) => {
-  return title
-    .toLowerCase()
+  return transliterate(title.toLowerCase())
     .replace(/[\s.,;:'"!?()„“”]+/g, '-') // Replace spaces and common punctuation with hyphens, including special quotes
     .replace(/^-+|-+$/g, '') // Trim leading/trailing hyphens
     .replace(/-+/g, '-'); // Collapse multiple hyphens


### PR DESCRIPTION
## Summary
- fix slug generation to transliterate Bulgarian text to Latin characters

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run type-check` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_b_686bfaadee80832898ae255591dc1a03