### PR TITLE
Restore handwritten announcement font

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,11 +1,12 @@
 import './globals.css'
-import { Inter, Montserrat } from 'next/font/google'
+import { Inter, Montserrat, Caveat } from 'next/font/google'
 import type { Metadata } from 'next'
 import { LanguageProvider } from '@/contexts/LanguageContext'
 import TranslatableNavigation from '@/components/TranslatableNavigation'
 
 const inter = Inter({ subsets: ['latin'], variable: '--font-inter' })
 const montserrat = Montserrat({ subsets: ['latin'], variable: '--font-montserrat' })
+const caveat = Caveat({ subsets: ['latin'], variable: '--font-caveat' })
 
 export const metadata: Metadata = {
   title: 'Nonprofit Organization',
@@ -23,7 +24,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={`${inter.className} ${montserrat.variable} ${inter.variable} bg-background text-foreground`}>
+      <body className={`${inter.className} ${montserrat.variable} ${inter.variable} ${caveat.variable} bg-background text-foreground`}>
         <LanguageProvider>
           <TranslatableNavigation />
           {children}

--- a/src/components/HomePageClient.tsx
+++ b/src/components/HomePageClient.tsx
@@ -40,7 +40,7 @@ export default function HomePageClient({ recentEvents }: HomePageClientProps) {
 
         {/* Announcements & News */}
         <section className="mt-12 bg-[var(--secondary-accent-ochre)] p-6 rounded-lg">
-          <p className="font-montserrat text-4xl font-bold text-[var(--text-charcoal)]">
+          <p className="font-caveat text-4xl font-bold text-[var(--text-charcoal)]">
             {t('newAnnouncement')}
           </p>
         </section>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -68,6 +68,7 @@ const config: Config = {
       fontFamily: {
         inter: ["var(--font-inter)"],
         montserrat: ["var(--font-montserrat)"],
+        caveat: ["var(--font-caveat)"],
       },
     },
   },


### PR DESCRIPTION
## Summary
- bring back Caveat Google Font
- use the Caveat font for announcement text

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: cannot find module 'next' and others)*

------
https://chatgpt.com/codex/tasks/task_b_686bfbb46a2c8328b13099f08df1dbf3