### PR TITLE
Remove placeholder contact info

### DIFF
--- a/src/components/HomePageClient.tsx
+++ b/src/components/HomePageClient.tsx
@@ -48,17 +48,8 @@ export default function HomePageClient({ recentEvents }: HomePageClientProps) {
 
       {/* Footer */}
       <footer className="bg-[var(--primary-accent-green)] text-white py-8">
-        <div className="container mx-auto px-6 flex flex-col md:flex-row justify-between">
-          <div>
-            <p>{t('contactEmail')}</p>
-            <p>{t('contactPhone')}</p>
-          </div>
-          <div className="flex space-x-4 mt-4 md:mt-0">
-            {/* Social Icon Placeholders */}
-            <span>FB</span>
-            <span>TW</span>
-            <span>IG</span>
-          </div>
+        <div className="container mx-auto px-6">
+          {/* Footer content removed */}
         </div>
       </footer>
     </div>

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -59,8 +59,6 @@ export const translations = {
     newAnnouncement: "A nation that does not remember its past has no present and no future.",
     
     // Footer
-    contactEmail: "info@example.org",
-    contactPhone: "(123) 456-7890",
     
     // Language switcher
     language: "Language",
@@ -138,8 +136,6 @@ export const translations = {
     newAnnouncement: "Народ, който не помни миналото си, няма настояще и бъдеще.",
     
     // Footer
-    contactEmail: "info@example.org",
-    contactPhone: "(123) 456-7890",
     
     // Language switcher
     language: "Език",


### PR DESCRIPTION
## Summary
- remove placeholder contact information from footer
- drop unused translation keys

## Testing
- `npm run type-check` *(fails: Cannot find module 'next' etc.)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_686bfbc58f888328ade3abe245243dd9