### PR TITLE
Use Traditsia branches list

### DIFF
--- a/src/components/BranchesClient.tsx
+++ b/src/components/BranchesClient.tsx
@@ -41,7 +41,9 @@ export default function BranchesClient({ branches }: BranchesClientProps) {
             <AccordionItem value={branch.City}>
               <AccordionTrigger className="text-xl font-semibold text-primary">{branch.City} - {branch.Name}</AccordionTrigger>
               <AccordionContent className="text-foreground">
-                <p className="flex items-center"><User className="mr-2 h-4 w-4" /><strong>{t('head')}</strong> {branch.Head}</p>
+                {branch.Head && (
+                  <p className="flex items-center"><User className="mr-2 h-4 w-4" /><strong>{t('head')}</strong> {branch.Head}</p>
+                )}
                 {branch.Phone && <p className="flex items-center"><Phone className="mr-2 h-4 w-4" /><strong>{t('phone')}</strong> {branch.Phone}</p>}
                 {branch.Email && <p className="flex items-center"><Mail className="mr-2 h-4 w-4" /><strong>{t('email')}</strong> {branch.Email}</p>}
               </AccordionContent>

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -23,7 +23,7 @@ export interface Event {
 export interface Branch {
   Name: string;
   City: string;
-  Head: string;
+  Head?: string;
   Phone?: string;
   Email?: string;
   Latitude: number;
@@ -111,13 +111,18 @@ export async function getEventBySlug(slug: string, locale: Language): Promise<Ev
 }
 
 
-export async function getBranches(locale: Language): Promise<Branch[]> {
-  const csvFileName = locale === 'en' ? 'branches.en.csv' : 'branches.csv';
-  const csvPath = path.join(process.cwd(), 'src', 'content', csvFileName);
+export async function getBranches(_locale: Language): Promise<Branch[]> {
+  const csvPath = path.join(
+    process.cwd(),
+    'src',
+    'content',
+    'Traditsia_Branches.csv'
+  );
   const content = await fs.readFile(csvPath, 'utf-8');
   const records = parse(content, {
     columns: true,
     skip_empty_lines: true,
+    bom: true,
   });
 
   const branches: Branch[] = records.map((record: any) => ({


### PR DESCRIPTION
## Summary
- update Branch interface to allow missing Head
- read branches from `Traditsia_Branches.csv` and handle BOM
- show Head only when provided on branch tiles

## Testing
- `npm run type-check` *(fails: cannot find modules)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_686bfd3203ac8328879772fd3fd00dc9