### PR TITLE
Fix static params for event pages

### DIFF
--- a/src/app/events/[slug]/page.tsx
+++ b/src/app/events/[slug]/page.tsx
@@ -1,27 +1,14 @@
 import { getEventBySlug, getEvents } from '@/lib/content';
 import EventDetailsClient from '@/components/EventDetailsClient';
-import { Language } from '@/lib/translations';
 
 export async function generateStaticParams() {
-  const locales: Language[] = ['bg', 'en'];
-  const allParams = [];
-
-  for (const lang of locales) {
-    const events = await getEvents(lang);
-    const params = events.map((event) => ({
-      slug: event.slug,
-      lang: lang,
-    }));
-    allParams.push(...params);
-  }
-
-  return allParams;
+  const events = await getEvents('bg');
+  return events.map((event) => ({ slug: event.slug }));
 }
 
-export default async function EventPage({ params: awaitedParams }: { params: Promise<{ slug: string, lang: Language }> }) {
-  const { slug, lang } = await awaitedParams;
-  const decodedSlug = decodeURIComponent(slug);
-  const event = await getEventBySlug(decodedSlug, lang);
+export default async function EventPage({ params }: { params: { slug: string } }) {
+  const decodedSlug = decodeURIComponent(params.slug);
+  const event = await getEventBySlug(decodedSlug, 'bg');
 
   if (!event) {
     return <div>Event not found</div>;


### PR DESCRIPTION
## Summary
- fix event details route to generate static params correctly

## Testing
- `npm run type-check` *(fails: Cannot find module 'next')*

------
https://chatgpt.com/codex/tasks/task_b_686bfda638c48328b0f60315c27b8789