### PR TITLE
Fix spacing for branch contact labels

### DIFF
--- a/src/components/BranchesClient.tsx
+++ b/src/components/BranchesClient.tsx
@@ -42,10 +42,10 @@ export default function BranchesClient({ branches }: BranchesClientProps) {
               <AccordionTrigger className="text-xl font-semibold text-primary">{branch.City} - {branch.Name}</AccordionTrigger>
               <AccordionContent className="text-foreground">
                 {branch.Head && (
-                  <p className="flex items-center"><User className="mr-2 h-4 w-4" /><strong>{t('head')}</strong> {branch.Head}</p>
+                  <p className="flex items-center"><User className="mr-2 h-4 w-4" /><strong className="mr-1">{t('head')}</strong>{branch.Head}</p>
                 )}
-                {branch.Phone && <p className="flex items-center"><Phone className="mr-2 h-4 w-4" /><strong>{t('phone')}</strong> {branch.Phone}</p>}
-                {branch.Email && <p className="flex items-center"><Mail className="mr-2 h-4 w-4" /><strong>{t('email')}</strong> {branch.Email}</p>}
+                {branch.Phone && <p className="flex items-center"><Phone className="mr-2 h-4 w-4" /><strong className="mr-1">{t('phone')}</strong>{branch.Phone}</p>}
+                {branch.Email && <p className="flex items-center"><Mail className="mr-2 h-4 w-4" /><strong className="mr-1">{t('email')}</strong>{branch.Email}</p>}
               </AccordionContent>
             </AccordionItem>
           </Accordion>


### PR DESCRIPTION
## Summary
- add margin-right to labels on branches page to ensure spacing between label and value

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails to find packages)*

------
https://chatgpt.com/codex/tasks/task_b_686bff04e14c8328b3bcfd1ed5d1ddb9