### PR TITLE
Add alternating tile colors for branches

### DIFF
--- a/src/components/BranchesClient.tsx
+++ b/src/components/BranchesClient.tsx
@@ -36,19 +36,24 @@ export default function BranchesClient({ branches }: BranchesClientProps) {
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-        {branches.map((branch, index) => (
-          <Accordion type="single" collapsible className="w-full" key={branch.City}>
-            <AccordionItem value={branch.City}>
-              <AccordionTrigger className="text-xl font-semibold text-primary">Регионален Клон - {branch.City}</AccordionTrigger>
-              <AccordionContent className="text-foreground">
-                {branch.Head && (
-                  <p className="flex items-center"><User className="mr-2 h-4 w-4" /><strong className="mr-1">{t('head')}</strong>{branch.Head}</p>
-                )}
-                {branch.Phone && <p className="flex items-center"><Phone className="mr-2 h-4 w-4" /><strong className="mr-1">{t('phone')}</strong>{branch.Phone}</p>}
-                {branch.Email && <p className="flex items-center"><Mail className="mr-2 h-4 w-4" /><strong className="mr-1">{t('email')}</strong>{branch.Email}</p>}
-              </AccordionContent>
-            </AccordionItem>
-          </Accordion>
+        {branches.map(branch => (
+          <div
+            key={branch.City}
+            className="p-4 rounded-xl bg-card border shadow hover:shadow-lg transition even:bg-[hsl(var(--primary-accent-green)/0.05)] odd:bg-[hsl(var(--secondary-accent-ochre)/0.05)]"
+          >
+            <Accordion type="single" collapsible className="w-full">
+              <AccordionItem value={branch.City}>
+                <AccordionTrigger className="text-xl font-semibold text-primary">Регионален Клон - {branch.City}</AccordionTrigger>
+                <AccordionContent className="text-foreground">
+                  {branch.Head && (
+                    <p className="flex items-center"><User className="mr-2 h-4 w-4" /><strong className="mr-1">{t('head')}</strong>{branch.Head}</p>
+                  )}
+                  {branch.Phone && <p className="flex items-center"><Phone className="mr-2 h-4 w-4" /><strong className="mr-1">{t('phone')}</strong>{branch.Phone}</p>}
+                  {branch.Email && <p className="flex items-center"><Mail className="mr-2 h-4 w-4" /><strong className="mr-1">{t('email')}</strong>{branch.Email}</p>}
+                </AccordionContent>
+              </AccordionItem>
+            </Accordion>
+          </div>
         ))}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add alternating background colors to branch tiles using accent colors
- add a visible border for clearer separation

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: cannot find modules)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_686c010ed6008328bf3993612ce86ba1