### PR TITLE
Fix branch accordion layout

### DIFF
--- a/src/components/BranchesClient.tsx
+++ b/src/components/BranchesClient.tsx
@@ -35,7 +35,7 @@ export default function BranchesClient({ branches }: BranchesClientProps) {
         <GoogleMap markers={markers} zoom={7} />
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 items-start">
         {branches.map(branch => (
           <div
             key={branch.City}


### PR DESCRIPTION
## Summary
- keep branch grid items from stretching when expanding

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: cannot find module 'next')*

------
https://chatgpt.com/codex/tasks/task_b_686c05625ccc8328bc57c67e73aba3d6