### PR TITLE
Add generateStaticParams for gallery

### DIFF
--- a/src/app/gallery/[album]/page.tsx
+++ b/src/app/gallery/[album]/page.tsx
@@ -8,6 +8,20 @@ import dynamic from 'next/dynamic';
 import { useLanguage } from '@/contexts/LanguageContext';
 import LanguageSwitcher from '@/components/LanguageSwitcher';
 
+export async function generateStaticParams() {
+  try {
+    const fs = await import('fs/promises');
+    const path = await import('path');
+    const galleryPath = path.join(process.cwd(), 'public', 'gallery');
+    const entries = await fs.readdir(galleryPath, { withFileTypes: true });
+    return entries
+      .filter(entry => entry.isDirectory())
+      .map(entry => ({ album: encodeURIComponent(entry.name) }));
+  } catch {
+    return [];
+  }
+}
+
 const ImageLightbox = dynamic(() => import('@/components/ImageLightbox'));
 
 interface AlbumImage {


### PR DESCRIPTION
## Summary
- return all gallery directories at build time in `generateStaticParams`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_b_686c194ba2b0832893b6fa2d6d0ba573