### PR TITLE
Translate event badges

### DIFF
--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -3,31 +3,34 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { motion } from 'framer-motion';
 import { Event } from '@/lib/content';
+import { useLanguage } from '@/contexts/LanguageContext';
 
 interface EventCardProps {
   event: Event;
   isPast?: boolean;
 }
 
-const typeBadges: Record<string, { label: string; className: string }> = {
-  country_wide: {
-    label: 'Държавно честване',
-    className:
-      'bg-blue-600 text-white shadow-[0_0_4px] shadow-blue-600/80',
-  },
-  local_event: {
-    label: 'Възстановка',
-    className:
-      'bg-green-600 text-white shadow-[0_0_4px] shadow-green-600/80',
-  },
-  national_event: {
-    label: 'Национална Възстановка',
-    className:
-      'bg-yellow-600 text-white shadow-[0_0_4px] shadow-yellow-600/80',
-  },
-};
-
 const EventCard: React.FC<EventCardProps> = ({ event, isPast }) => {
+  const { t } = useLanguage();
+
+  const typeBadges: Record<string, { label: string; className: string }> = {
+    country_wide: {
+      label: t('countryWideBadge'),
+      className:
+        'bg-blue-600 text-white shadow-[0_0_4px] shadow-blue-600/80',
+    },
+    local_event: {
+      label: t('localEventBadge'),
+      className:
+        'bg-green-600 text-white shadow-[0_0_4px] shadow-green-600/80',
+    },
+    national_event: {
+      label: t('nationalEventBadge'),
+      className:
+        'bg-yellow-600 text-white shadow-[0_0_4px] shadow-yellow-600/80',
+    },
+  };
+
   const badge = !isPast ? typeBadges[event.Type] : undefined;
 
   return (
@@ -45,7 +48,7 @@ const EventCard: React.FC<EventCardProps> = ({ event, isPast }) => {
             <span
               className="bg-gray-600 text-white shadow-[0_0_4px] shadow-gray-600/80 absolute top-2 left-2 z-10 px-2 py-1 text-xs font-semibold rounded"
             >
-              Минало Събитие
+              {t('pastEvent')}
             </span>
           ) : (
             badge && (

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -44,6 +44,10 @@ export const translations = {
     date: "Date",
     location: "Location",
     description: "Description",
+    countryWideBadge: "State Celebration",
+    localEventBadge: "Reenactment",
+    nationalEventBadge: "National Reenactment",
+    pastEvent: "Past Event",
 
     // Contact page
     contactSubtitle: "Get in touch with us to learn more about our work or to get involved.",
@@ -121,6 +125,10 @@ export const translations = {
     location: "Място",
     email: "Имейл",
     description: "Описание",
+    countryWideBadge: "Държавно честване",
+    localEventBadge: "Възстановка",
+    nationalEventBadge: "Национална Възстановка",
+    pastEvent: "Минало Събитие",
 
     // Contact page
     contactSubtitle: "Свържете се с нас, за да научите повече за нашата работа или да се включите.",


### PR DESCRIPTION
## Summary
- add translations for badge labels and past event tag
- use translations in `EventCard`

## Testing
- `npx next lint` *(fails: 403 Forbidden to download packages)*
- `npm run type-check` *(fails: cannot find packages)*

------
https://chatgpt.com/codex/tasks/task_b_686d01c7442c832885c98500657d37ab