### PR TITLE
Fix build by removing unused lang params

### DIFF
--- a/src/app/branches/page.tsx
+++ b/src/app/branches/page.tsx
@@ -1,9 +1,8 @@
 import { getBranches } from '@/lib/content';
 import BranchesClient from '@/components/BranchesClient';
-import { Language } from '@/lib/translations';
 
-export default async function BranchesPage({ params: { lang } }: { params: { lang: Language } }) {
-  const branches = await getBranches(lang);
+export default async function BranchesPage() {
+  const branches = await getBranches('bg');
 
   return (
     <BranchesClient branches={branches} />

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -1,10 +1,9 @@
 
 import { getEvents } from '@/lib/content';
 import EventsPageClient from '@/components/EventsPageClient';
-import { Language } from '@/lib/translations';
 
-export default async function EventsPage({ params: { lang } }: { params: { lang: Language } }) {
-  const events = await getEvents(lang);
+export default async function EventsPage() {
+  const events = await getEvents('bg');
 
   return (
     <EventsPageClient initialEvents={events} />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,8 @@
 import { getEvents, Event } from '@/lib/content';
 import HomePageClient from '@/components/HomePageClient';
-import { Language } from '@/lib/translations';
 
-export default async function HomePage({ params: { lang } }: { params: { lang: Language } }) {
-  const upcomingEvents = await getEvents(lang);
+export default async function HomePage() {
+  const upcomingEvents = await getEvents('bg');
 
   const now = new Date();
   now.setHours(0, 0, 0, 0);


### PR DESCRIPTION
## Summary
- remove unused `params.lang` from pages
- default to Bulgarian data when fetching

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_686d2a65ebc483288858a1e52bd51ad7