### PR TITLE
Fix slug page typing

### DIFF
--- a/src/app/events/[slug]/page.tsx
+++ b/src/app/events/[slug]/page.tsx
@@ -1,12 +1,13 @@
 import { getEventBySlug, getEvents } from '@/lib/content';
 import EventDetailsClient from '@/components/EventDetailsClient';
+import type { PageProps } from 'next';
 
 export async function generateStaticParams() {
   const events = await getEvents('bg');
   return events.map((event) => ({ slug: event.slug }));
 }
 
-export default async function EventPage({ params }: { params: { slug: string } }) {
+export default async function EventPage({ params }: PageProps<{ slug: string }>) {
   const decodedSlug = decodeURIComponent(params.slug);
   const event = await getEventBySlug(decodedSlug, 'bg');
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -72,7 +72,7 @@ const config: Config = {
       },
     },
   },
-  plugins: [require("tailwindcss-animate"), require("@tailwindcss/line-clamp")],
+  plugins: [require("tailwindcss-animate")],
 }
 export default config
  


### PR DESCRIPTION
## Summary
- use Next.js PageProps for slug page
- remove line-clamp plugin since Tailwind 3.3 bundles it

## Testing
- `npm run type-check` *(fails: Cannot find module 'next')*

------
https://chatgpt.com/codex/tasks/task_b_686d2b90ee588328b59687eda263d0c3