### PR TITLE
Fix gallery page params type

### DIFF
--- a/src/app/gallery/[album]/page.tsx
+++ b/src/app/gallery/[album]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from 'next/navigation';
 import fs from 'fs/promises';
 import path from 'path';
 import AlbumPageClient, { AlbumImage } from '@/components/AlbumPageClient';
+import type { PageProps } from 'next';
 
 export async function generateStaticParams() {
   try {
@@ -15,7 +16,7 @@ export async function generateStaticParams() {
   }
 }
 
-export default async function AlbumPage({ params }: { params: { album: string } }) {
+export default async function AlbumPage({ params }: PageProps<{ album: string }>) {
   const albumName = decodeURIComponent(params.album);
   const albumPath = path.join(process.cwd(), 'public', 'gallery', albumName);
 


### PR DESCRIPTION
## Summary
- adjust `src/app/gallery/[album]/page.tsx` to use Next.js `PageProps`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_b_686d2c7d55e48328bc23b9a7471e49e9