### PR TITLE
Remove PageProps import causing build error

### DIFF
--- a/src/app/events/[slug]/page.tsx
+++ b/src/app/events/[slug]/page.tsx
@@ -1,13 +1,17 @@
 import { getEventBySlug, getEvents } from '@/lib/content';
 import EventDetailsClient from '@/components/EventDetailsClient';
-import type { PageProps } from 'next';
+interface EventPageProps {
+  params: {
+    slug: string;
+  };
+}
 
 export async function generateStaticParams() {
   const events = await getEvents('bg');
   return events.map((event) => ({ slug: event.slug }));
 }
 
-export default async function EventPage({ params }: PageProps<{ slug: string }>) {
+export default async function EventPage({ params }: EventPageProps) {
   const decodedSlug = decodeURIComponent(params.slug);
   const event = await getEventBySlug(decodedSlug, 'bg');
 

--- a/src/app/gallery/[album]/page.tsx
+++ b/src/app/gallery/[album]/page.tsx
@@ -2,7 +2,11 @@ import { notFound } from 'next/navigation';
 import fs from 'fs/promises';
 import path from 'path';
 import AlbumPageClient, { AlbumImage } from '@/components/AlbumPageClient';
-import type { PageProps } from 'next';
+interface AlbumPageProps {
+  params: {
+    album: string;
+  };
+}
 
 export async function generateStaticParams() {
   try {
@@ -16,7 +20,7 @@ export async function generateStaticParams() {
   }
 }
 
-export default async function AlbumPage({ params }: PageProps<{ album: string }>) {
+export default async function AlbumPage({ params }: AlbumPageProps) {
   const albumName = decodeURIComponent(params.album);
   const albumPath = path.join(process.cwd(), 'public', 'gallery', albumName);
 


### PR DESCRIPTION
## Summary
- remove `PageProps` type import from Next.js
- inline prop interfaces for dynamic pages

## Testing
- `npm run type-check` *(fails: Cannot find type definition file for 'json5', etc.)*

------
https://chatgpt.com/codex/tasks/task_b_686d30a5a0b48328bdac56adeb580312