### PR TITLE
Fix slug page param types

### DIFF
--- a/src/app/events/[slug]/page.tsx
+++ b/src/app/events/[slug]/page.tsx
@@ -1,9 +1,9 @@
 import { getEventBySlug, getEvents } from '@/lib/content';
 import EventDetailsClient from '@/components/EventDetailsClient';
 interface EventPageProps {
-  params: {
+  params: Promise<{
     slug: string;
-  };
+  }>;
 }
 
 export async function generateStaticParams() {
@@ -12,7 +12,8 @@ export async function generateStaticParams() {
 }
 
 export default async function EventPage({ params }: EventPageProps) {
-  const decodedSlug = decodeURIComponent(params.slug);
+  const { slug } = await params;
+  const decodedSlug = decodeURIComponent(slug);
   const event = await getEventBySlug(decodedSlug, 'bg');
 
   if (!event) {


### PR DESCRIPTION
## Summary
- fix invalid params type in event detail page

## Testing
- `npm run type-check` *(fails: Cannot find module)*

------
https://chatgpt.com/codex/tasks/task_b_686d321e8e1c8328bcaa333c2d8daf1c