### PR TITLE
Add type checking to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,4 +143,6 @@ npm run build
 npm run start
 ```
 
+The `build` script first runs linting and a TypeScript check so you can see all issues in one run. You can also execute `npm run check` separately to only perform the type check.
+
 Alternatively, `npm run export` generates a static `out/` directory that can be hosted on any static file server.

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
-    "export": "next build && next export",
-    "start": "next start",
+    "check": "tsc --noEmit",
     "lint": "next lint",
-    "type-check": "tsc --noEmit"
+    "build": "npm run lint && npm run check && next build",
+    "export": "next build && next export",
+    "start": "next start"
   },
   "dependencies": {
     "@googlemaps/js-api-loader": "^1.16.10",


### PR DESCRIPTION
## Summary
- run lint and TypeScript check before building
- document the new build behaviour in README

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_b_686d32b95f488328be013ddcd992e302