### PR TITLE
Fix type definitions for dynamic pages

### DIFF
--- a/src/app/events/[slug]/page.tsx
+++ b/src/app/events/[slug]/page.tsx
@@ -1,17 +1,17 @@
 import { getEventBySlug, getEvents } from '@/lib/content';
 import EventDetailsClient from '@/components/EventDetailsClient';
-interface EventPageProps {
+export interface PageProps {
   params: {
     slug: string;
   };
 }
 
-export async function generateStaticParams() {
+export async function generateStaticParams(): Promise<PageProps['params'][]> {
   const events = await getEvents('bg');
   return events.map((event) => ({ slug: event.slug }));
 }
 
-export default async function EventPage({ params }: EventPageProps) {
+export default async function EventPage({ params }: PageProps) {
   const decodedSlug = decodeURIComponent(params.slug);
   const event = await getEventBySlug(decodedSlug, 'bg');
 

--- a/src/app/gallery/[album]/page.tsx
+++ b/src/app/gallery/[album]/page.tsx
@@ -2,13 +2,13 @@ import { notFound } from 'next/navigation';
 import fs from 'fs/promises';
 import path from 'path';
 import AlbumPageClient, { AlbumImage } from '@/components/AlbumPageClient';
-interface AlbumPageProps {
+export interface PageProps {
   params: {
     album: string;
   };
 }
 
-export async function generateStaticParams() {
+export async function generateStaticParams(): Promise<PageProps['params'][]> {
   try {
     const galleryPath = path.join(process.cwd(), 'public', 'gallery');
     const entries = await fs.readdir(galleryPath, { withFileTypes: true });
@@ -20,7 +20,7 @@ export async function generateStaticParams() {
   }
 }
 
-export default async function AlbumPage({ params }: AlbumPageProps) {
+export default async function AlbumPage({ params }: PageProps) {
   const albumName = decodeURIComponent(params.album);
   const albumPath = path.join(process.cwd(), 'public', 'gallery', albumName);
 


### PR DESCRIPTION
## Summary
- export `PageProps` from dynamic `events` page and use it for `generateStaticParams`
- export `PageProps` from dynamic `gallery` page and use it for `generateStaticParams`

## Testing
- `tsc --noEmit` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_b_686d349da91c8328b64b7251a60a8f0b