### PR TITLE
Fix dynamic page param types

### DIFF
--- a/src/app/events/[slug]/page.tsx
+++ b/src/app/events/[slug]/page.tsx
@@ -1,19 +1,20 @@
-import { getEventBySlug, getEvents } from '@/lib/content';
-import EventDetailsClient from '@/components/EventDetailsClient';
-export interface PageProps {
+import { getEventBySlug, getEvents } from '@/lib/content'
+import EventDetailsClient from '@/components/EventDetailsClient'
+
+type PageProps = {
   params: {
-    slug: string;
-  };
+    slug: string
+  }
 }
 
-export async function generateStaticParams(): Promise<PageProps['params'][]> {
-  const events = await getEvents('bg');
-  return events.map((event) => ({ slug: event.slug }));
+export async function generateStaticParams(): Promise<{ slug: string }[]> {
+  const events = await getEvents('bg')
+  return events.map((event) => ({ slug: event.slug }))
 }
 
 export default async function EventPage({ params }: PageProps) {
-  const decodedSlug = decodeURIComponent(params.slug);
-  const event = await getEventBySlug(decodedSlug, 'bg');
+  const decodedSlug = decodeURIComponent(params.slug)
+  const event = await getEventBySlug(decodedSlug, 'bg')
 
   if (!event) {
     return <div>Event not found</div>;

--- a/src/app/gallery/[album]/page.tsx
+++ b/src/app/gallery/[album]/page.tsx
@@ -1,22 +1,23 @@
-import { notFound } from 'next/navigation';
-import fs from 'fs/promises';
-import path from 'path';
-import AlbumPageClient, { AlbumImage } from '@/components/AlbumPageClient';
-export interface PageProps {
+import { notFound } from 'next/navigation'
+import fs from 'fs/promises'
+import path from 'path'
+import AlbumPageClient, { AlbumImage } from '@/components/AlbumPageClient'
+
+type PageProps = {
   params: {
-    album: string;
-  };
+    album: string
+  }
 }
 
-export async function generateStaticParams(): Promise<PageProps['params'][]> {
+export async function generateStaticParams(): Promise<{ album: string }[]> {
   try {
-    const galleryPath = path.join(process.cwd(), 'public', 'gallery');
-    const entries = await fs.readdir(galleryPath, { withFileTypes: true });
+    const galleryPath = path.join(process.cwd(), 'public', 'gallery')
+    const entries = await fs.readdir(galleryPath, { withFileTypes: true })
     return entries
       .filter(entry => entry.isDirectory())
-      .map(entry => ({ album: encodeURIComponent(entry.name) }));
+      .map(entry => ({ album: encodeURIComponent(entry.name) }))
   } catch {
-    return [];
+    return []
   }
 }
 


### PR DESCRIPTION
## Summary
- correct local type definitions for dynamic pages
- avoid referencing type aliases in `generateStaticParams`

## Testing
- `npm run check` *(fails: Cannot find module 'next' or its corresponding type declarations)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_686d35b8ae7083289b549b253099069e