### PR TITLE
Fix static export for GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,13 +21,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build and Export the site
+      - name: Build the site
         env:
           NEXT_PUBLIC_BASE_PATH: traditsia-site
           NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: ${{ secrets.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY }}
-        run: |
-          npm run build
-          npm run export
+        run: npm run build
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,7 +5,7 @@ const basePath = process.env.NEXT_PUBLIC_BASE_PATH
   : ''
 
 const nextConfig: NextConfig = {
-  // output: 'export', // disabled to support API routes and SSR
+  output: 'export',
   trailingSlash: true,
   basePath,
   assetPrefix: basePath ? `${basePath}/` : undefined,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "check": "tsc --noEmit",
     "lint": "next lint",
     "build": "npm run lint && npm run check && next build",
-    "export": "next build && next export",
+    "export": "next build",
     "start": "next start"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- enable Next.js static export in `next.config.ts`
- simplify build step to just run `next build`
- adjust GitHub Actions workflow accordingly

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686d426a457883288d9f8b3d7e11def8