### PR TITLE
Fix GH Pages permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master  # Change to 'main' if your default branch is named 'main'
 
+permissions:
+  contents: write
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- fix GitHub Pages deployment permission error

## Testing
- `npm ci` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_b_686e164413bc8328b3d1d4ffc887985d