### PR TITLE
Fix album path encoding

### DIFF
--- a/src/app/gallery/[album]/page.tsx
+++ b/src/app/gallery/[album]/page.tsx
@@ -12,7 +12,7 @@ export async function generateStaticParams(): Promise<{ album: string }[]> {
     const entries = await fs.readdir(galleryPath, { withFileTypes: true })
     return entries
       .filter(entry => entry.isDirectory())
-      .map(entry => ({ album: encodeURIComponent(entry.name) }))
+      .map(entry => ({ album: entry.name }))
   } catch {
     return []
   }

--- a/src/components/GalleryPageClient.tsx
+++ b/src/components/GalleryPageClient.tsx
@@ -26,7 +26,7 @@ export default function GalleryPageClient({ albums }: Props) {
             {albums.map(album => (
               <Link
                 key={album.name}
-                href={`/gallery/${encodeURIComponent(album.name)}`}
+                href={`/gallery/${album.name}`}
                 className="block bg-[var(--background-soft-cream)] rounded-xl overflow-hidden shadow hover:shadow-lg transition-shadow duration-300"
               >
                 <div className="aspect-video relative">


### PR DESCRIPTION
## Summary
- fix album slug generation for gallery pages
- ensure gallery links use raw album names

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_686e1bc690808328a789b2a207b88d8a