### PR TITLE
Fix gallery image paths with basePath

### DIFF
--- a/src/app/gallery/[album]/page.tsx
+++ b/src/app/gallery/[album]/page.tsx
@@ -23,6 +23,10 @@ export default async function AlbumPage({ params }: { params: Promise<{ album: s
   const albumName = decodeURIComponent(album);
   const albumPath = path.join(process.cwd(), 'public', 'gallery', albumName);
 
+  const basePath = process.env.NEXT_PUBLIC_BASE_PATH
+    ? `/${process.env.NEXT_PUBLIC_BASE_PATH.replace(/^\\//, '')}`
+    : '';
+
   try {
     await fs.access(albumPath);
   } catch {
@@ -32,7 +36,10 @@ export default async function AlbumPage({ params }: { params: Promise<{ album: s
   const files = await fs.readdir(albumPath);
   const images: AlbumImage[] = files
     .filter(file => /\.(jpe?g|png|gif|webp)$/i.test(file))
-    .map(fileName => ({ name: fileName, src: `/gallery/${albumName}/${fileName}` }));
+    .map(fileName => ({
+      name: fileName,
+      src: `${basePath}/gallery/${albumName}/${fileName}`,
+    }));
 
   return <AlbumPageClient albumName={albumName} images={images} />;
 }

--- a/src/lib/gallery.ts
+++ b/src/lib/gallery.ts
@@ -26,8 +26,12 @@ export async function getAlbumList(): Promise<AlbumMeta[]> {
         const files = await fs.readdir(albumPath);
         const imageFiles = files.filter(file => /\.(jpe?g|png|gif|webp)$/i.test(file));
 
+        const basePath = process.env.NEXT_PUBLIC_BASE_PATH
+          ? `/${process.env.NEXT_PUBLIC_BASE_PATH.replace(/^\\//, '')}`
+          : '';
+
         const cover = imageFiles.length > 0
-          ? `/gallery/${albumName}/${imageFiles[Math.floor(Math.random() * imageFiles.length)]}`
+          ? `${basePath}/gallery/${albumName}/${imageFiles[Math.floor(Math.random() * imageFiles.length)]}`
           : null;
 
         return {


### PR DESCRIPTION
## Summary
- ensure gallery cover and album images include NEXT_PUBLIC_BASE_PATH

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_686e1fad3860832887a9748a3196da49