### PR TITLE
Fix regex escaping in gallery base path

### DIFF
--- a/src/app/gallery/[album]/page.tsx
+++ b/src/app/gallery/[album]/page.tsx
@@ -24,7 +24,7 @@ export default async function AlbumPage({ params }: { params: Promise<{ album: s
   const albumPath = path.join(process.cwd(), 'public', 'gallery', albumName);
 
   const basePath = process.env.NEXT_PUBLIC_BASE_PATH
-    ? `/${process.env.NEXT_PUBLIC_BASE_PATH.replace(/^\\//, '')}`
+    ? `/${process.env.NEXT_PUBLIC_BASE_PATH.replace(/^\//, '')}`
     : '';
 
   try {

--- a/src/lib/gallery.ts
+++ b/src/lib/gallery.ts
@@ -27,7 +27,7 @@ export async function getAlbumList(): Promise<AlbumMeta[]> {
         const imageFiles = files.filter(file => /\.(jpe?g|png|gif|webp)$/i.test(file));
 
         const basePath = process.env.NEXT_PUBLIC_BASE_PATH
-          ? `/${process.env.NEXT_PUBLIC_BASE_PATH.replace(/^\\//, '')}`
+          ? `/${process.env.NEXT_PUBLIC_BASE_PATH.replace(/^\//, '')}`
           : '';
 
         const cover = imageFiles.length > 0


### PR DESCRIPTION
## Summary
- correct regex escaping for base paths in gallery

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'next' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_b_686e228aec5c83289bd0ff52768345c7