### PR TITLE
Fix image paths for basePath

### DIFF
--- a/src/components/HomePageClient.tsx
+++ b/src/components/HomePageClient.tsx
@@ -6,6 +6,10 @@ import Link from 'next/link';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { Event } from '@/lib/content';
 
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH
+  ? `/${process.env.NEXT_PUBLIC_BASE_PATH.replace(/^\//, '')}`
+  : '';
+
 import EventCard from './EventCard';
 
 interface HomePageClientProps {
@@ -20,7 +24,7 @@ export default function HomePageClient({ recentEvents }: HomePageClientProps) {
       {/* Hero */}
       <section className="relative w-full h-[28vw] min-h-[100px] sm:h-[25vw] sm:min-h-[150px] max-h-[300px]">
         <Image
-          src="/images/site-banner.webp"
+          src={`${basePath}/images/site-banner.webp`}
           alt="Traditsia Banner"
           fill
           className="object-cover"

--- a/src/components/TranslatableNavigation.tsx
+++ b/src/components/TranslatableNavigation.tsx
@@ -2,6 +2,10 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import { useState } from 'react';
+
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH
+  ? `/${process.env.NEXT_PUBLIC_BASE_PATH.replace(/^\//, '')}`
+  : '';
 import { useLanguage } from '@/contexts/LanguageContext';
 import LanguageSwitcher from '@/components/LanguageSwitcher';
 
@@ -23,7 +27,7 @@ export default function TranslatableNavigation() {
       <div className="container mx-auto flex items-center justify-between py-4 px-6">
         <Link href="/" className="flex items-center space-x-4 cursor-pointer">
           <Image
-            src="/images/gerb.jpg"
+            src={`${basePath}/images/gerb.jpg`}
             alt="Traditsia Logo"
             width={50}
             height={50}

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -50,6 +50,10 @@ const generateSlug = (title: string) => {
 
 import { Language } from '@/lib/translations';
 
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH
+  ? `/${process.env.NEXT_PUBLIC_BASE_PATH.replace(/^\//, '')}`
+  : '';
+
 export async function getEvents(locale: Language): Promise<Event[]> {
   const csvFileName = locale === 'en' ? 'events.en.csv' : 'events.csv';
   const csvPath = path.join(process.cwd(), 'src', 'content', csvFileName);
@@ -65,15 +69,19 @@ export async function getEvents(locale: Language): Promise<Event[]> {
     from_line: 2,
   });
 
-  const allEvents: Event[] = records.map((record: any) => ({
-    ...record,
-    EventID: (record.EventID || '').padStart(5, '0'),
-    Latitude: parseFloat(record.Latitude),
-    Longitude: parseFloat(record.Longitude),
-    slug: generateSlug(record.Title || ''),
-    Type: record.Type || '',
-    ImagePath: String(record.ImagePath || '').trim() || '/images/events/placeholder.jpg',
-  }));
+  const allEvents: Event[] = records.map((record: any) => {
+    const rawPath = String(record.ImagePath || '').trim() || '/images/events/placeholder.jpg';
+    const cleaned = rawPath.replace(/^\//, '');
+    return {
+      ...record,
+      EventID: (record.EventID || '').padStart(5, '0'),
+      Latitude: parseFloat(record.Latitude),
+      Longitude: parseFloat(record.Longitude),
+      slug: generateSlug(record.Title || ''),
+      Type: record.Type || '',
+      ImagePath: `${basePath}/${cleaned}`,
+    };
+  });
 
   const now = new Date();
   now.setHours(0, 0, 0, 0);


### PR DESCRIPTION
## Summary
- prefix image paths with `NEXT_PUBLIC_BASE_PATH` so they work on GitHub Pages
- update event loader to add basePath to each event image

## Testing
- `npm install` *(fails: ENOTFOUND registry.npmjs.org)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_686e243040d483288f1eab5d551faf58