### PR TITLE
Adjust mobile menu sizing

### DIFF
--- a/src/components/TranslatableNavigation.tsx
+++ b/src/components/TranslatableNavigation.tsx
@@ -41,7 +41,7 @@ export default function TranslatableNavigation() {
         {/* Hamburger menu button for mobile */}
         <div className="md:hidden flex items-center">
           <button onClick={() => setIsMenuOpen(!isMenuOpen)} className="text-[var(--primary-accent-green)] focus:outline-none">
-            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d={isMenuOpen ? "M6 18L18 6M6 6l12 12" : "M4 6h16M4 12h16M4 18h16"}></path>
             </svg>
           </button>
@@ -72,7 +72,7 @@ export default function TranslatableNavigation() {
               <Link
                 key={item.key}
                 href={`/${item.href}`}
-                className="block w-full text-center py-2 text-[var(--text-charcoal)] hover:bg-gray-100"
+                className="block w-full text-center py-2 text-lg text-[var(--text-charcoal)] hover:bg-gray-100"
                 onClick={() => setIsMenuOpen(false)} // Close menu on item click
               >
                 {t(item.key as any)}
@@ -85,5 +85,4 @@ export default function TranslatableNavigation() {
         </div>
       )}
     </header>
-  );
-}
+  );}


### PR DESCRIPTION
## Summary
- enlarge the hamburger button
- bump up mobile menu text size

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check` *(fails: cannot find module 'next')*

------
https://chatgpt.com/codex/tasks/task_b_686e42fa4908832899e3b3e2df4980b9