### PR TITLE
Use env file for Google Maps key

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,11 @@ To run this project locally:
     npm install
     ```
 3.  **Set up environment variables:**
-    Copy `env.example` to `.env.local` and fill in your Google Maps API key:
+    Copy `env.example` to `.env.local` and replace the Google Maps key placeholder with your real key. The `.env.local` file is ignored by Git so your secret won't be committed:
     ```
-    NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=your_google_maps_api_key
+    NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=your_real_key_here
     ```
+    When deploying, define the same variable (`NEXT_PUBLIC_GOOGLE_MAPS_API_KEY`) as a repository secret so the build workflow can access it.
 4.  **Run the development server:**
     ```bash
     npm run dev

--- a/env.example
+++ b/env.example
@@ -1,3 +1,5 @@
+# Copy this file to `.env.local` and set your real values
+
 # Google Maps API Key
 NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=your_google_maps_api_key_here
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -10,15 +10,8 @@ const nextConfig: NextConfig = {
   basePath,
   assetPrefix: basePath ? `${basePath}/` : undefined,
   images: { unoptimized: true },
-  webpack: (config) => {
-    config.plugins.push(
-      new (require('webpack').DefinePlugin)({
-        'process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY': JSON.stringify(
-          process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY
-        ),
-      })
-    )
-    return config
+  env: {
+    NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY,
   },
 }
 


### PR DESCRIPTION
## Summary
- clarify how to store the Google Maps API key

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run check` *(fails due to missing modules)*
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_b_686e4c2c7ee08328a638d224f426b90f