### PR TITLE
Fix base path for custom domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,9 @@ To run this project locally:
 ## Deploying to GitHub Pages
 
 The build script automatically detects when it runs inside a GitHub workflow and
-applies the correct base path for your repository. When testing locally you can
-override this by setting `NEXT_PUBLIC_BASE_PATH`.
+applies the correct base path for your repository. If you are using a custom
+domain (no `/traditsia-site` path) set `NEXT_PUBLIC_BASE_PATH` to an empty
+string, otherwise set it to your repository name.
 
 1. **Export the static site**
    ```bash

--- a/env.example
+++ b/env.example
@@ -10,6 +10,6 @@ NEXT_PUBLIC_SITE_URL=http://localhost:3000
 CONTACT_EMAIL=contact@yourorganization.org
 
 # Base path for GitHub Pages (optional)
-# Override auto-detection if you need a custom value
-# Example: my-project
+# Set to the repository name when hosting under
+# `<user>.github.io/<repo>`, or leave blank for a custom domain.
 NEXT_PUBLIC_BASE_PATH=

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,20 +1,26 @@
 import type { NextConfig } from 'next'
 
-// Detect if we are building the GitHub Pages version. When running in a GitHub
-// workflow (GITHUB_REPOSITORY is defined) and not on a platform like Vercel
-// (NEXT_PUBLIC_VERCEL_ENV is undefined), we assume assets should be served from
-// the repository subpath.
+// Base path can be explicitly provided via environment variable. This allows
+// hosting the site either at the root of a custom domain or under a repository
+// subpath when deploying to GitHub Pages.
+const envBase = process.env.NEXT_PUBLIC_BASE_PATH
+  ? `/${process.env.NEXT_PUBLIC_BASE_PATH.replace(/^\/+|\/+$/g, '')}`
+  : null
+
+// Detect GitHub Pages to apply the repository subpath when no override exists.
 const isGitHubPages =
+  !envBase &&
   !process.env.NEXT_PUBLIC_VERCEL_ENV &&
   process.env.GITHUB_REPOSITORY?.endsWith('traditsia-site')
 
-const basePath = isGitHubPages ? '/traditsia-site' : ''
+const basePath = envBase ?? (isGitHubPages ? '/traditsia-site' : '')
+const assetPrefix = envBase ? `${envBase}/` : isGitHubPages ? '/traditsia-site/' : '/'
 
 const nextConfig: NextConfig = {
   output: 'export',
   trailingSlash: true,
   basePath,
-  assetPrefix: isGitHubPages ? '/traditsia-site/' : '/',
+  assetPrefix,
   images: { unoptimized: true },
   env: {
     NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY,


### PR DESCRIPTION
## Summary
- allow overriding basePath using `NEXT_PUBLIC_BASE_PATH`
- document base path setting for custom domains
- clarify base path usage in env template

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check` *(fails: cannot find module 'next')*

------
https://chatgpt.com/codex/tasks/task_b_686f7215b9a48328a13495d4e441183c